### PR TITLE
Add english content for wave 5 including promos

### DIFF
--- a/src/ENG/index.ts
+++ b/src/ENG/index.ts
@@ -13,6 +13,7 @@ import { theDepthsData } from './theDepths'
 import { theNamelessData } from './theNameless'
 import { theVoidData } from './theVoid'
 import { warEternalData } from './warEternal'
+import { outcastsData } from './outcasts'
 
 const ENG: IExpansionData = {
   AE: aeonsEndData,
@@ -27,6 +28,7 @@ const ENG: IExpansionData = {
   TA: theAncientsData,
   TV: theVoidData,
   WE: warEternalData,
+  O: outcastsData,
   promos: promosData,
 }
 

--- a/src/ENG/index.ts
+++ b/src/ENG/index.ts
@@ -14,6 +14,7 @@ import { theNamelessData } from './theNameless'
 import { theVoidData } from './theVoid'
 import { warEternalData } from './warEternal'
 import { outcastsData } from './outcasts'
+import { returnToGraveholdData } from './returnToGravehold'
 
 const ENG: IExpansionData = {
   AE: aeonsEndData,
@@ -29,6 +30,7 @@ const ENG: IExpansionData = {
   TV: theVoidData,
   WE: warEternalData,
   O: outcastsData,
+  RTG: returnToGraveholdData,
   promos: promosData,
 }
 

--- a/src/ENG/index.ts
+++ b/src/ENG/index.ts
@@ -15,6 +15,7 @@ import { theVoidData } from './theVoid'
 import { warEternalData } from './warEternal'
 import { outcastsData } from './outcasts'
 import { returnToGraveholdData } from './returnToGravehold'
+import { southernVillageData } from './southernVillage'
 
 const ENG: IExpansionData = {
   AE: aeonsEndData,
@@ -31,6 +32,7 @@ const ENG: IExpansionData = {
   WE: warEternalData,
   O: outcastsData,
   RTG: returnToGraveholdData,
+  SV: southernVillageData,
   promos: promosData,
 }
 

--- a/src/ENG/outcasts/basicNemesisCards.ts
+++ b/src/ENG/outcasts/basicNemesisCards.ts
@@ -1,0 +1,355 @@
+import { BasicNemesisCard } from 'aer-types'
+
+export const basicNemesisCards: BasicNemesisCard[] = [
+  {
+    id: 'WitheringRot-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Attack',
+    name: 'Withering Rot',
+    effect: `
+      <p>
+        Any player suffers 3 damage and gains a Curse of Rot from the Curse deck.
+      </p>
+    `,
+  },
+  {
+    id: 'WeepingHex-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Attack',
+    name: 'Weeping Hex',
+    effect: `
+      <p>
+        Unleash.<br />
+        <br />
+        Any player suffers 2 damage, gains a Cursed Shard from the Curse deck, and 
+        places it on top of their deck.
+      </p>
+    `,
+  },
+  {
+    id: 'Hemorrhage-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Attack',
+    name: 'Hemorrhage',
+    effect: `
+      <p>
+        Unleash.<br />
+        <br />
+        Gravehold suffers 1 damage.<br />
+        <br />
+        Place this in front of the player with the most opened breaches.<br />
+        <br />
+        At the start of that player's turn they suffer 1 damage. When that player gains a card 
+        that costs 5 <span class="aether">&AElig;</span> or more, this card is discarded.<br />
+        If there are no cards in the supply that cost 5 <span class="aether">&AElig;</span> or more, 
+        discard this when they gain a card with the highest cost in the supply.
+      </p>
+    `,
+  },
+  {
+    id: 'MoonstruckHound-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Minion',
+    name: 'Moonstruck Hound',
+    hp: 5,
+    effect: `
+      <p>
+        Reduce to 1 all damage dealt to this minion by spells that cost 5 <span class="aether">&AElig;</span> 
+        or more.<br />
+        <b>Persistent:</b> Gravehold suffers 2 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'WanderingLasher-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Minion',
+    name: 'Wandering Lasher',
+    hp: 6,
+    effect: `
+      <p>
+        <b>Wandering</b> <span class="hint">(Reduce to 1 all damage that is dealt to this 
+        by abilities and player cards. During any player's main phase, that player 
+        may spend any amount of <span class="aether">&AElig;</span> to deal an 
+        equal amount of damage to this.)</span><br />
+        <b>Persistent:</b> Unleash.
+      </p>
+    `,
+  },
+  {
+    id: 'AuraDrain-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Power',
+    name: 'Aura Drain',
+    power: 2,
+    effect: `
+      <p>
+        When a power token is removed from this, any player suffers 2 damage.<br />
+        <br />
+        <b>To Discard:</b> Spend 5 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Unleash.
+      </p>
+    `,
+  },
+  {
+    id: 'HauntedForce-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Power',
+    name: 'Haunted Force',
+    power: 2,
+    effect: `
+      <p>
+        <b>Power 2:</b> Unleash. Gravehold suffers 2 damage. Any player gaines 
+        a Cursed Bolt from the Curse deck.
+      </p>
+    `,
+  },
+  {
+    id: 'NoxiousWinds-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Power',
+    name: 'Noxious Winds',
+    power: 2,
+    effect: `
+      <p>
+        <b>To Discard:</b> Spend 5 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Gravehold suffers 3 damage. Any player gains a Cursed Shard 
+        from the Curse deck. Any player gains a Cursed Bolt from the Curse deck.
+      </p>
+    `,
+  },
+  {
+    id: 'MarkedForDeath-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Attack',
+    name: 'Marked For Death',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        Place this card in front of any player.<br />
+        <br />
+        For the rest of the game, when a nemesis card specifies 'any player' 
+        the player with this card must resolve that effect if possible.<br />
+        <br />
+        When the player with this card becomes exhausted, discard this.
+      </p>
+    `,
+  },
+  {
+    id: 'ConjuredGrapple-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Attack',
+    name: 'Conjured Grapple',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        Any player suffers 2 damage and discards two cards in hand. That 
+        player gains a Cursed Manacles from the Curse deck and places it into 
+        their hand.
+      </p>
+    `,
+  },
+  {
+    id: 'ChitinCrawler-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Minion',
+    name: 'Chitin Crawler',
+    hp: 9,
+    effect: `
+      <p>
+        Reduce to 1 all damage dealt to this minion by spells that cost 3 <span class="aether">&AElig;</span> 
+        or less.<br />
+        <b>Persistent:</b> Any player suffers 3 damage.
+        <span class="or">OR</span>
+        Unleash.
+      </p>
+    `,
+  },
+  {
+    id: 'WanderingObserver-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Minion',
+    name: 'Wandering Observer',
+    hp: 11,
+    effect: `
+      <p>
+        <b>Wandering</b> <span class="hint">(Reduce to 1 all damage that is dealt to this 
+        by abilities and player cards. During any player's main phase, that player 
+        may spend any amount of <span class="aether">&AElig;</span> to deal an 
+        equal amount of damage to this.)</span><br />
+        <b>Persistent:</b> Gravehold suffers 2 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'SeekingDestruction-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Power',
+    name: 'Seeking Destruction',
+    power: 3,
+    effect: `
+      <p>
+        <b>Immediately:</b> Place the player number token of the player with the most opened breaches 
+        on this.<br />
+        <br />
+        <b>To Discard:</br> Spend 7 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 3:</b> If the player whose player token is on this has the most opened breaches, 
+        that player suffers 5 damage. Otherwise, Unleash twice.
+      </p>
+    `,
+  },
+  {
+    id: 'SuffocatingHaze-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Power',
+    name: 'Suffocating Haze',
+    power: 3,
+    effect: `
+      <p>
+        Reduce by 1 all damage dealt to minions from the nemesis deck, to a minimum of 1.<br />
+        <br />
+        <b>Power 3:</b> Unleash twice. Gravehold suffers 2 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'ToxicSubterfuge-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Power',
+    name: 'Toxic Subterfuge',
+    power: 3,
+    effect: `
+      <p>
+        When a power token is removed from this, Gravehold suffers 2 damage.<br />
+        <br />
+        <b>To Discard:</b> Spend 7 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 3:</b> Unleash.
+      </p>
+    `,
+  },
+  {
+    id: 'Throttle-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Attack',
+    name: 'Throttle',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        Any player destroys their three most expensive cards in hand.
+      </p>
+    `,
+  },
+  {
+    id: 'Topple-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Attack',
+    name: 'Topple',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        Gravehold suffers 4 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'BreachSpike-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Attack',
+    name: 'Breach Spike',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        The player with the most prepped spells suffers 3 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'NyxTheSpineCruncher-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Minion',
+    name: 'Nyx, The Spine Cruncher',
+    hp: 14,
+    effect: `
+      <p>
+        <b>Persistent:</b> Unleash. Any player suffers 2 damage.      
+      </p>
+    `,
+  },
+  {
+    id: 'EndlessTorment-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Power',
+    name: 'Endless Torment',
+    power: 2,
+    effect: `
+      <p>
+        <b>To Discard:</br> Spend 8 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Unleash three times.
+        <span class="or">OR</span>
+        Any player suffers 6 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'DarkeningDepths-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Power',
+    name: 'Darkening Depths',
+    power: 1,
+    effect: `
+      <p>
+        <b>To Discard:</br> Destroy a prepped spell that costs 3 <span class="aether">&AElig;</span> 
+        or more and a breach in which it was prepped.<br />
+        <br />
+        <b>Power 1:</b> Unleash. The player with the lowest life suffers 3 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'ApocalypseRitual-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Power',
+    name: 'Apocalypse Ritual',
+    power: 2,
+    effect: `
+      <p>
+        <b>To Discard:</br> Spend 8 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Gravehold suffers 5 damage for each nemesis turn order card in the turn order 
+        discard pile.
+      </p>
+    `,
+  },
+]

--- a/src/ENG/outcasts/cards.ts
+++ b/src/ENG/outcasts/cards.ts
@@ -1,0 +1,471 @@
+import { ICard } from 'aer-types'
+
+export const cards: ICard[] = [
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Unstable Pyrite',
+    id: 'UnstablePyrite',
+    cost: 2,
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.<br />
+        You may destroy this. If you do, gain an additional 2 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Molten Peridot',
+    id: 'MoltenPeridot',
+    cost: 3,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        If this is the second time you have played Molten Peridot this turn, 
+        you may destroy this. If you do, gain a card that costs 4 <span class="aether">&AElig;</span> 
+        or less from any supply pile.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Helix Of Amber',
+    id: 'HelixOfAmber',
+    cost: 3,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        You may suffer 1 damage. If you do, destroy a card that costs 0 <span class="aether">&AElig;</span> 
+        in your hand.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Petrified Phoenixium',
+    id: 'PetrifiedPhoenixium',
+    cost: 4,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        The next time you gain a card this turn, you may cast any player's prepped spell.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Galvanized Sapphire',
+    id: 'GalvanizedSapphire',
+    cost: 4,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        Xaxos: Outcast gains 1 charge.
+      </p>
+    `,
+    keywords: ['xaxos'],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Elongated Looq',
+    id: 'ElongatedLooq',
+    cost: 4,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        The next time you focus or open a breach this turn, gain 1 charge.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Vigorous Sunstone',
+    id: 'VigorousSunstone',
+    cost: 5,
+    effect: `
+      <p>
+        When you gain this, if this is the second card you gained this turn, 
+        place it into your hand.<br />
+        Gain 3 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'O',
+    name: 'Duplicating Sazite',
+    id: 'DuplicatingSazite',
+    cost: 6,
+    effect: `
+      <p>
+        Gain 3 <span class="aether">&AElig;</span>.<br />
+        The next time you gain a card this turn, you may discard a prepped spell 
+        that costs 1 <span class="aether">&AElig;</span> or more. If you do, 
+        any ally gains a card from the supply that costs less than or equal to the card 
+        you gained.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Orb Of The Deep',
+    id: 'OrbOfTheDeep',
+    cost: 2,
+    effect: `
+      <p>
+        Focus your closed breach with the lowest focus cost.
+        <span class="or">OR</span>
+        Destroy this. Gain 1 charge.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Carnivorous Roox',
+    id: 'CarnivorousRoox',
+    cost: 3,
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>. You may destroy a card in hand 
+        to gain <span class="aether">&AElig;</span> equal to its cost.
+        <span class="or">OR</span>
+        Destroy this. Focus your closed breach with the lowest focus cost twice.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Rift Dagger',
+    id: 'RiftDagger',
+    cost: 3,
+    effect: `
+      <p>
+        Gain a card from any other supply pile that costs 3 <span class="aether">&AElig;</span> 
+        or less. You may destroy this to gain a card that costs up to 4 <span class="aether">&AElig;</span> 
+        instead.<br />
+        You may spend 1 <span class="aether">&AElig;</span>. If you do, place that card 
+        into your hand.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Reconstituting Circuit',
+    id: 'ReconstitutingCircuit',
+    cost: 3,
+    effect: `
+      <p>
+        Xaxos: Outcast gains 1 charge.<br />
+        You may destroy a card in hand.
+      </p>
+    `,
+    keywords: ['xaxos'],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Destiny Forger',
+    id: 'DestinyForger',
+    cost: 4,
+    effect: `
+      <p>
+        Any ally may destroy a card in hand. That player may gain a card that costs 
+        up to 2 <span class="aether">&AElig;</span> more than the destroyed card and 
+        place it into their hands.
+        <span class="or">OR</span>
+        Destroy this. Gain 2 charges.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Chain Of Retrieval',
+    id: 'ChainOfRetrieval',
+    cost: 4,
+    effect: `
+      <p>
+        Focus any ally's breach.
+        <span class="or">OR</span>
+        Return a card in your discard pile to your hand that costs 
+        6 <span class="aether">&AElig;</span> or less.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Bottled Sun',
+    id: 'BottledSun',
+    cost: 6,
+    effect: `
+      <p>
+        Xaxos: Outcast gains 3 charges.
+      </p>
+    `,
+    keywords: ['xaxos'],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Transmuter\'s Lens',
+    id: 'TransmutersLens',
+    cost: 5,
+    effect: `
+      <p>
+        Destroy this.<br />
+        You may destroy a card in your hand or discard pile.<br />
+        Gain a card that costs up to 6 <span class="aether">&AElig;</span> from 
+        any supply pile.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'O',
+    name: 'Unhinged Vortex',
+    id: 'UnhingedVortex',
+    cost: 7,
+    effect: `
+      <p>
+        Any ally draws three cards. Then, they discard a card in hand.
+        <span class="or">OR</span>
+        You may focus any ally's breach. Any ally may return a card in their discard pile 
+        to their hand.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Fortified Frost',
+    id: 'FortifiedFrost',
+    cost: 2,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 2 damage.<br />
+        You may discard a card in hand. If you do, deal 1 additional damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Paired Storm',
+    id: 'PairedStorm',
+    cost: 3,
+    effect: `
+      <p>
+        <b>Link</b> <span class="hint">(Two spells with Link may be prepped to the same breach.)</span>
+      </p>
+      <p>
+        <b>Cast:</b> Deal 2 damage.<br />
+        If this is the second time you have cast a Paired Storm this turn, 
+        deal 2 additional damage.
+      </p>
+    `,
+    keywords: ['link'],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Twisted Fang',
+    id: 'TwistedFang',
+    cost: 4,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 3 damage.<br />
+        If this card's supply pile is empty, deal 1 additional damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Shattering Bolt',
+    id: 'ShatteringBolt',
+    cost: 4,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 2 damage.<br />
+        You may destroy a card in your hand.
+        <span class="or">OR</span>
+        <b>Cast:</b> Discard a gem in hand.<br />
+        If you do, deal 4 damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Infused Ignition',
+    id: 'InfusedIgnition',
+    cost: 4,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 3 damage.<br />
+        If Xaxos: Outcast has 4 or less charges, he gains 1 charge.
+      </p>
+    `,
+    keywords: ['xaxos'],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Lightning Arrow',
+    id: 'LightningArrow',
+    cost: 5,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 3 damage.<br />
+        You may discard a card in hand. If you do, Gravehold gains 1 life.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Radiant Conflux',
+    id: 'RadiantConflux',
+    cost: 5,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 3 damage.<br />
+        Any ally may draw a card and then discard a card in hand.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Unstable Rift',
+    id: 'UnstableRift',
+    cost: 5,
+    effect: `
+      <p>
+        While prepped, at the end of your casting phase deal 1 damage and 
+        gain 1 <span class="aether">&AElig;</span>.<br />
+        <b>Cast:</br> Deal 4 damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Gathered Will',
+    id: 'GatheredWill',
+    cost: 5,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 2 damage.<br />
+        You may gain a spell from any supply pile that costs 4 <span class="aether">&AElig;</span> 
+        or less and place it on top of your deck.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Tornado Of Insight',
+    id: 'TornadoOfInsight',
+    cost: 6,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 5 damage.<br />
+        If you have no closed breaches, gain 1 charge.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Hasted Intellect',
+    id: 'HastedIntellect',
+    cost: 6,
+    effect: `
+      <p>
+        While prepped, when you gain a card, you may place that card on top 
+        of your deck.
+        <b>Cast:</b> Deal 4 damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Swarm Of Flame',
+    id: 'SwarmOfFlame',
+    cost: 6,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 5 damage.<br />
+        You may cast any player's prepped spell that costs 5 <span class="aether">&AElig;</span> or less.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Arcane Relay',
+    id: 'ArcaneRelay',
+    cost: 8,
+    effect: `
+      <p>
+        <b>Cast:</b> Any ally draws a card then reveals their hand.<br />
+        Deal 4 damage. Deal 1 additional damage for each card in that ally's 
+        hand that costs 1 <span class="aether">&AElig;</span> or more.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'O',
+    name: 'Dizzying Burst',
+    id: 'DizzyingBurst',
+    cost: 8,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 6 damage.<br />
+        Reveal the turn order deck.<br />
+        Return it in any order.
+      </p>
+    `,
+    keywords: [],
+  },
+]

--- a/src/ENG/outcasts/index.ts
+++ b/src/ENG/outcasts/index.ts
@@ -1,0 +1,20 @@
+import { IExpansion } from 'aer-types'
+
+import { nemeses } from './nemeses'
+import { mages } from './mages'
+import { cards } from './cards'
+import { treasures } from './treasures'
+import { basicNemesisCards } from './basicNemesisCards'
+import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
+
+export const outcastsData: IExpansion = {
+  id: 'O',
+  name: 'Outcasts',
+  type: 'standalone',
+  nemeses,
+  mages,
+  cards,
+  treasures,
+  basicNemesisCards,
+  upgradedBasicNemesisCards
+}

--- a/src/ENG/outcasts/mages.ts
+++ b/src/ENG/outcasts/mages.ts
@@ -1,0 +1,365 @@
+import { Mage } from 'aer-types'
+
+export const mages: Mage[] = [
+  {
+    expansion: 'O',
+    name: 'Ilya',
+    id: 'Ilya',
+    mageTitle: '',
+    ability: `
+      <h2>Life Embrace</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Cast all of your prepped spells without discarding them. 
+        Any ally returns a card in their discard pile to their hand.
+      </p>
+    `,
+    numberOfCharges: 5,
+    uniqueStarters: [
+      {
+        type: 'Gem',
+        name: 'Entwined Amethyst',
+        expansion: 'O',
+        id: 'EntwinedAmethyst',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            When you discard this during an ally's turn, you gain 1 charge.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Entwined Amethyst',
+        expansion: 'O',
+        id: 'EntwinedAmethyst',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            When you discard this during an ally's turn, you gain 1 charge.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Trulite Of Force',
+        expansion: 'O',
+        id: 'TruliteOfForce',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            Any ally may discard a card in hand. If they do, gain 1 <span class="aether">&AElig;</span> that 
+            can only be used to gain a spell or to focus or open a breach.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Trulite Of Force',
+        expansion: 'O',
+        id: 'TruliteOfForce',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            Any ally may discard a card in hand. If they do, gain 1 <span class="aether">&AElig;</span> that 
+            can only be used to gain a spell or to focus or open a breach.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 4,
+  },
+  {
+    expansion: 'O',
+    name: 'Kel',
+    id: 'Kel',
+    mageTitle: '',
+    ability: `
+      <h2>Soul Invigoration</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Return up to two gems or relics you played this turn to your hand. 
+        Any ally draws a card and may prep a spell in hand to an opened or closed breach.
+      </p>
+    `,
+    numberOfCharges: 6,
+    uniqueStarters: [
+      {
+        type: 'Gem',
+        name: 'Entwined Amethyst',
+        expansion: 'O',
+        id: 'EntwinedAmethyst',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            When you discard this during an ally's turn, you gain 1 charge.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Entwined Amethyst',
+        expansion: 'O',
+        id: 'EntwinedAmethyst',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            When you discard this during an ally's turn, you gain 1 charge.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Trulite Of Energy',
+        expansion: 'O',
+        id: 'TruliteOfEnergy',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            Any ally may discard a card in hand. If they do, gain 1 <span class="aether">&AElig;</span> that 
+            can only be used to gain a gem or relic.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Trulite Of Energy',
+        expansion: 'O',
+        id: 'TruliteOfEnergy',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br/>
+            Any ally may discard a card in hand. If they do, gain 1 <span class="aether">&AElig;</span> that 
+            can only be used to gain a gem or relic.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 4,
+  },
+  {
+    expansion: 'O',
+    name: 'Z\'hana',
+    id: 'ZhanaO',
+    mageTitle: '',
+    ability: `
+      <h2>Inscribe</h2>
+      <p class="ability-activation">Activate during any player's main phase:</p>
+      <p>
+        Gravehold gains 5 life. Place two glyph tokens on top of any card in the supply.
+      </p>
+    `,
+    numberOfCharges: 5,
+    uniqueStarters: [
+      {
+        type: 'Gem',
+        name: 'Glyph Carver',
+        expansion: 'O',
+        id: 'GlyphCarver',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.
+            <span class="or">OR</span>
+            Place 1 glyph token on top of any card in the supply.
+          </p>
+        `,
+        keywords: [],
+      },
+      {
+        type: 'Gem',
+        name: 'Glyph Carver',
+        expansion: 'O',
+        id: 'GlyphCarver',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.
+            <span class="or">OR</span>
+            Place 1 glyph token on top of any card in the supply.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 3,
+  },
+  {
+    expansion: 'O',
+    name: 'Taqren',
+    id: 'TaqrenO',
+    mageTitle: '',
+    ability: `
+      <h2>Sustain</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        If you are not exhausted, gain 3 life.<br />
+        Otherwise, Gravehold gains 3 life.
+      </p>
+    `,
+    numberOfCharges: 5,
+    uniqueStarters: [
+      {
+        type: 'Gem',
+        name: 'Esoteric Amplifier',
+        expansion: 'O',
+        id: 'EsotericAmplifier',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.<br />
+            You may suffer 1 damage.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 6,
+  },
+  {
+    expansion: 'O',
+    name: 'Qu',
+    id: 'QuO',
+    mageTitle: '',
+    ability: `
+      <h2>Combust Aether</h2>
+      <p class="ability-activation">Activate at the end of your draw phase:</p>
+      <p>
+        Draw three cards.
+      </p>
+    `,
+    numberOfCharges: 4,
+    uniqueStarters: [
+      {
+        type: 'Spell',
+        name: 'Call Of The Void',
+        expansion: 'O',
+        id: 'CallOfTheVoid',
+        cost: 0,
+        effect: `
+          <p>
+            While prepped, the first time you play a gem or relic that costs 1 <span class="aether">&AElig;</span> or more 
+            each turn, play that card twice and then return it to the supply.<br/>
+            <b>Cast:</b> Deal 1 damage.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 7,
+  },
+  {
+    expansion: 'O',
+    name: 'Thraxir',
+    id: 'Thraxir',
+    mageTitle: '',
+    ability: `
+      <h2>Shackles Unleashed</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Cast up to three spells prepped by any players. If you have three opened breaches, 
+        those spells deal 1 additional damage. If you have four opened breaches, 
+        you may cast up to four spells and those spells deal 2 additional damage instead.
+      </p>
+    `,
+    numberOfCharges: 5,
+    uniqueStarters: [
+      {
+        type: 'Gem',
+        name: 'Nameless Siphon',
+        expansion: 'O',
+        id: 'NamelessSiphon',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.
+            <span class="or">OR</span>
+            Any ally may discard a card in hand. If they do, focus one of your breaches.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 5,
+  },
+  {
+    expansion: 'O',
+    name: 'Dezmodia',
+    id: 'DezmodiaO',
+    mageTitle: '',
+    ability: `
+      <h2>Void Vortex</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Any ally draws three cards. Then, place any number of cards in your hand into their hand. 
+        Then, that ally places the same number of cards in their hand into your hand.
+      </p>
+    `,
+    numberOfCharges: 4,
+    uniqueStarters: [
+      {
+        type: 'Spell',
+        name: 'Swirling Darkness',
+        expansion: 'O',
+        id: 'SwirlingDarkness',
+        cost: 0,
+        effect: `
+          <p>
+            This may be prepped to closed breaches.<br />
+            <b>Cast:</b> Focus the breach this was cast from.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 7,
+  },
+  {
+    expansion: 'O',
+    name: 'Arachnos',
+    id: 'Arachnos',
+    mageTitle: '',
+    ability: `
+      <h2>Expunge</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Cast any player's prepped spell. That spell deals 3 additional damage.
+      </p>
+    `,
+    numberOfCharges: 6,
+    uniqueStarters: [
+      {
+        type: 'Spell',
+        name: 'Convergence',
+        expansion: 'O',
+        id: 'Convergence',
+        cost: 0,
+        effect: `
+          <p>
+            While prepped, when you play a gem or relic that costs 3 <span class="aether">&AElig;</span> or more, 
+            gain 1 charge.<br />
+            <b>Cast:</b> Deal 1 damage.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 3,
+  },
+]

--- a/src/ENG/outcasts/nemeses.ts
+++ b/src/ENG/outcasts/nemeses.ts
@@ -1,0 +1,40 @@
+import { Nemesis } from 'aer-types'
+
+export const nemeses: Nemesis[] = [
+  {
+    expansion: 'O',
+    name: 'Experiment 153',
+    id: 'Experiment153',
+    health: 80, // * > 4 * 20 per maw
+    difficulty: 3,
+    expeditionRating: 1,
+    additionalInfo: '',
+  },
+  {
+    expansion: 'O',
+    name: 'Thief Of Dreams',
+    id: 'ThiefOfDreams',
+    health: 80,
+    difficulty: 4,
+    expeditionRating: 2,
+    additionalInfo: '',
+  },
+  {
+    expansion: 'O',
+    name: 'Risen Thrall',
+    id: 'RisenThrall',
+    health: 50,
+    difficulty: 5,
+    expeditionRating: 3,
+    additionalInfo: '',
+  },
+  {
+    expansion: 'O',
+    name: 'Fountain Of Souls',
+    id: 'FountainOfSouls',
+    health: 70,
+    difficulty: 8,
+    expeditionRating: 4,
+    additionalInfo: '',
+  },
+]

--- a/src/ENG/outcasts/treasures.ts
+++ b/src/ENG/outcasts/treasures.ts
@@ -1,0 +1,166 @@
+import { Treasure } from 'aer-types'
+
+export const treasures: Treasure[] = [
+  {
+    id: 'RhiasPlanarPocket',
+    name: 'Rhia\'s Planar Pocket',
+    expansion: 'O',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.<br />
+        Gain an additional <span class="aether">&AElig;</span> that can only be used 
+        to gain a relic.
+      </p>
+    `,
+  },
+  {
+    id: 'TalixsEverburn',
+    name: 'Talix\'s Everburn',
+    expansion: 'O',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.<br />
+        Discard up to three spells in hand. Gain 1 <span class="aether">&AElig;</span> 
+        for each spell discarded this way.
+      </p>
+    `,
+  },
+  {
+    id: 'LostsForgedSpark',
+    name: 'Lost\'s Forged Spark',
+    expansion: 'O',
+    level: 1,
+    subtype: 'Spell',
+    effect: `
+      <p>
+        <span class="hint">(When the game starts, add a Crystal to your discard pile.)</span><br />
+        <b>Cast:</br> Deal 2 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'MazrasThesis',
+    name: 'Mazra\'s Thesis',
+    expansion: 'O',
+    level: 1,
+    subtype: 'Spell',
+    effect: `
+      <p>
+        <b>Cast:</br> Deal 1 damage.<br />
+        Focus any player's III breach.
+      </p>
+    `,
+  },
+  {
+    id: 'RazrasTrainingWhistle',
+    name: 'Razra\'s Training Whistle',
+    expansion: 'O',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>. 
+        <span class="or">OR</span>
+        Gain 1 charge.
+      </p>
+    `,
+  },
+  {
+    id: 'RejuvenatingDiamond',
+    name: 'Rejuvenating Diamond',
+    expansion: 'O',
+    level: 2,
+    effect: `
+      <p>
+        When Gravehold gains life, Gravehold gains an additional 1 life.
+      </p>
+    `,
+  },
+  {
+    id: 'BrokenTooth',
+    name: 'Broken Tooth',
+    expansion: 'O',
+    level: 2,
+    effect: `
+      <p>
+        When a player opens a breach, any ally draws a card.
+      </p>
+    `,
+  },
+  {
+    id: 'PoisonHeart',
+    name: 'Poison Heart',
+    expansion: 'O',
+    level: 2,
+    effect: `
+      <p>
+        At the start of the game, set this next to a spell supply pile that 
+        costs 5 <span class="aether">&AElig;</span> or less. Those spells deal 
+        1 additional damage when cast.
+      </p>
+    `,
+  },
+  {
+    id: 'WorldMarble',
+    name: 'World Marble',
+    expansion: 'O',
+    level: 3,
+    effect: `
+      <p>
+        At the start of your first turn of the game, focus one of your breaches 
+        three times.
+      </p>
+    `,
+  },
+  {
+    id: 'ArmoredPauldrons',
+    name: 'Armored Pauldrons',
+    expansion: 'O',
+    level: 3,
+    effect: `
+      <p>
+        When you play a relic that costs 3 <span class="aether">&AElig;</span> 
+        or more, deal 1 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'BloodshotGeode',
+    name: 'Bloodshot Geode',
+    expansion: 'O',
+    level: 3,
+    effect: `
+      <p>
+        When you play a gem that costs 5 <span class="aether">&AElig;</span> 
+        or more, deal 2 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'TreasuredStone',
+    name: 'Treasured Stone',
+    expansion: 'O',
+    level: 3,
+    effect: `
+      <p>
+        At the start of your first turn of the game, gain a gem from any supply pile.
+      </p>
+    `,
+  },
+  {
+    id: 'ReboundGauntlet',
+    name: 'Rebound Gauntlet',
+    expansion: 'O',
+    level: 3,
+    effect: `
+      <p>
+        Once per turn, when you cast a spell that costs 5 <span class="aether">&AElig;</span> 
+        or less, you may discard a spell in hand to return the cast spell to your hand.
+      </p>
+    `,
+  },
+]

--- a/src/ENG/outcasts/upgradedBasicNemesisCards.ts
+++ b/src/ENG/outcasts/upgradedBasicNemesisCards.ts
@@ -1,0 +1,241 @@
+import { UpgradedBasicNemesisCard } from 'aer-types'
+
+export const upgradedBasicNemesisCards: UpgradedBasicNemesisCard[] = [
+  {
+    id: 'ChaosStrike',
+    name: 'Chaos Strike',
+    expansion: 'O',
+    tier: 1,
+    type: 'Attack',
+    effect: `
+      <p>
+        Unleash.<br />
+        <br />
+        Gravehold suffers 4 damage.<br />
+        <br />
+        Any player gains a Cursed Shard from the Curse deck and places it on top of their deck.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'LabyrinthWraith-O',
+    expansion: 'O',
+    tier: 1,
+    type: 'Minion',
+    name: 'Labyrinth Wraith',
+    hp: 6,
+    effect: `
+      <p>
+        <b>Wandering</b> <span class="hint">(Reduce to 1 all damage that is dealt to this 
+        by abilities and player cards. During any player's main phase, that player 
+        may spend any amount of <span class="aether">&AElig;</span> to deal an 
+        equal amount of damage to this.)</span><br />
+        <b>Persistent:</b> Unleash. Any player suffers 1 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'RainOfDevastation',
+    name: 'Rain Of Devastation',
+    expansion: 'O',
+    tier: 1,
+    type: 'Power',
+    power: 2,
+    effect: `
+      <p>
+        <b>To Discard:</b> Spend 6 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Unleash twice. Any player suffers 3 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'HuntTheWeak',
+    name: 'Hunt The Weak',
+    expansion: 'O',
+    tier: 2,
+    type: 'Attack',
+    effect: `
+      <p>
+        Any player suffers 3 damage.<br />
+        <br />
+        Gravehold suffers 3 damage.<br />
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'Rescind',
+    name: 'Rescind',
+    expansion: 'O',
+    tier: 2,
+    type: 'Attack',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        The player with the most expensive prepped spell discards that spell and suffers 2 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'HarbingerOfMonstrosity-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Minion',
+    name: 'Harbinger Of Monstrosity',
+    hp: 8,
+    effect: `
+      <p>
+        When a player deals damage to this minion, reduce that damage by 2, 
+        to a minimum of 1.<br />
+        <b>Persistent:</b> Gravehold suffers 2 damage. Any player discards a card in hand.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'MageDevourer-O',
+    expansion: 'O',
+    tier: 2,
+    type: 'Minion',
+    name: 'Mage Devourer',
+    hp: 11,
+    effect: `
+      <p>
+        When a player deals damage to this minion, the player with the most opened breaches 
+        suffers 1 damage.<br />
+        <b>Persistent:</b> Unleash. Gravehold suffers 1 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'SilentDecay',
+    name: 'Silent Decay',
+    expansion: 'O',
+    tier: 2,
+    type: 'Power',
+    power: 2,
+    effect: `
+      <p>
+        <b>To Discard:</b> Spend 8 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Unleash twice. Gravehold suffers 3 damage. Any player gains a Cursed Bolt 
+        from the Curse deck and places it on top of their deck.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'SkyCrush',
+    name: 'Sky Crush',
+    expansion: 'O',
+    tier: 3,
+    type: 'Attack',
+    effect: `
+      <p>
+        Unleash three times.<br />
+        <br />
+        Any player destroys two cards in hand and suffers 2 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'Scour',
+    name: 'Scour',
+    expansion: 'O',
+    tier: 3,
+    type: 'Attack',
+    effect: `
+      <p>
+        Unleash three times.<br />
+        <br />
+        The player with the most expensive card in hand discards their three most expensive cards in hand.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'Sacrifice',
+    name: 'Sacrifice',
+    expansion: 'O',
+    tier: 3,
+    type: 'Attack',
+    effect: `
+      <p>
+        Unleash four times.
+        <span class="or">OR</span>
+        Gravehold suffers 4 damage and any player suffers 4 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'ScionOfTheVoid-O',
+    expansion: 'O',
+    tier: 3,
+    type: 'Minion',
+    name: 'Scion Of The Void',
+    hp: 13,
+    effect: `
+      <p>
+        When a player deals damage to this minion, Unleash.<br />
+        <b>Persistent:</b> Unleash twice.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'RayOfDesolation',
+    name: 'Ray Of Desolation',
+    expansion: 'O',
+    tier: 3,
+    type: 'Power',
+    power: 1,
+    effect: `
+      <p>
+        <b>Power 1:</b> Unleash twice. The players collectively destroy the two most expensive 
+        prepped spells.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'BlightedMagic',
+    name: 'Blighted Magic',
+    expansion: 'O',
+    tier: 3,
+    type: 'Power',
+    power: 2,
+    effect: `
+      <p>
+        <b>Power 2:</b> Unleash. The player with the most expensive prepped spell destroyed it. 
+        A different player destroys two cards in hand that cost 1 <span class="aether">&AElig;</span> 
+        or more.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'BlackenedStars',
+    name: 'Blackened Stars',
+    expansion: 'O',
+    tier: 3,
+    type: 'Power',
+    power: 2,
+    effect: `
+      <p>
+        <b>To Discard:</b> Spend 9 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 2:</b> Any player suffers 7 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+]

--- a/src/ENG/promos/cards.ts
+++ b/src/ENG/promos/cards.ts
@@ -9,12 +9,12 @@ export const cards: ICard[] = [
     cost: 6,
     effect: `
       <p>
-      <b>Cast:</b> Deal 4 damage to a minion or the nemesis.<br/>
-        You may lose 2 charges. If you do, repeat this.<br/>
+        <b>Cast:</b> Deal 4 damage to a minion or the nemesis.<br />
+        You may lose 2 charges. If you do, repeat this.<br />
         <span class="hint">(Effects that modify damage affect each 
         instance of damage this spell deals)</span>
-        </p>
-        `,
+      </p>
+    `,
     keywords: [],
   },
   {
@@ -25,11 +25,11 @@ export const cards: ICard[] = [
     cost: 3,
     effect: `
       <p>
-      <b>Cast:</b> Deal 2 damage.<br/>
-      Each player may reveal the top two cards of their deck and may discard 
-      any of those cards.
-        </p>
-      `,
+        <b>Cast:</b> Deal 2 damage.<br />
+        Each player may reveal the top two cards of their deck and may discard 
+        any of those cards.
+      </p>
+    `,
     keywords: [],
   },
   {
@@ -40,12 +40,12 @@ export const cards: ICard[] = [
     cost: 5,
     effect: `
       <p>
-      <b>Cast:</b> Deal 4 damage.<br/>
-      Any ally may discard a card in hand. 
-      If they do, divide this damage however you choose among the nemesis 
-      and any number of minions.
-        </p>
-      `,
+        <b>Cast:</b> Deal 4 damage.<br />
+        Any ally may discard a card in hand. 
+        If they do, divide this damage however you choose among the nemesis 
+        and any number of minions.
+      </p>
+    `,
     keywords: [],
   },
   {
@@ -56,11 +56,11 @@ export const cards: ICard[] = [
     cost: 4,
     effect: `
       <p>
-      Gain 2 <span class="aether">&AElig;</span>.<br/>
-      If you have played another Echo Stone this turn, gain an additional 
-      1 <span class="aether">&AElig;</span>.
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        If you have played another Echo Stone this turn, gain an additional 
+        1 <span class="aether">&AElig;</span>.
       </p>
-      `,
+    `,
     keywords: [],
   },
   {
@@ -71,10 +71,10 @@ export const cards: ICard[] = [
     cost: 5,
     effect: `
       <p>
-        <b>Cast:</b> Deal 4 damage.<br/>
+        <b>Cast:</b> Deal 4 damage.<br />
         Gain 1 <span class="aether">&AElig;</span>.
-        </p>
-        `,
+      </p>
+    `,
     keywords: [],
   },
   {
@@ -85,11 +85,11 @@ export const cards: ICard[] = [
     cost: 4,
     effect: `
       <p>
-      Gain 2 <span class="aether">&AElig;</span>.<br/>
-      You may destroy two cards in this card's supply pile. If you do, 
-      gain an additional 1 <span class="aether">&AElig;</span>.
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        You may destroy two cards in this card's supply pile. If you do, 
+        gain an additional 1 <span class="aether">&AElig;</span>.
       </p>
-      `,
+    `,
     keywords: [],
   },
   {
@@ -100,9 +100,9 @@ export const cards: ICard[] = [
     cost: 3,
     effect: `
       <p>
-      Discard or destroy a card in hand. If you do, deal damage equal to its cost.
+        Discard or destroy a card in hand. If you do, deal damage equal to its cost.
       </p>
-      `,
+    `,
     keywords: [],
   },
   {
@@ -113,10 +113,10 @@ export const cards: ICard[] = [
     cost: 4,
     effect: `
       <p>
-      You may casdt any ally's prepped spell.<br/>
-      Any ally draws a card.
+        You may casdt any ally's prepped spell.<br />
+        Any ally draws a card.
       </p>
-      `,
+    `,
     keywords: [],
   },
   {
@@ -127,11 +127,11 @@ export const cards: ICard[] = [
     cost: 6,
     effect: `
       <p>
-      <b>Cast:</b> Deal 5 damage.<br/>
-      If this was cast from an opened III or IV breach, you may destroy this.
+        <b>Cast:</b> Deal 5 damage.<br/>
+        If this was cast from an opened III or IV breach, you may destroy this.
         If you do, gain 3 charges.
-        </p>
-      `,
+      </p>
+    `,
     keywords: [],
   },
   {
@@ -143,11 +143,56 @@ export const cards: ICard[] = [
     effect: `
       <p>
         This spell must be prepped to two adjacent breaches so that this card 
-        touches both breaches. This fully occupies both breaches.<br/>
-        <b>Cast:</b> Deal 4 damage.<br/>
+        touches both breaches. This fully occupies both breaches.<br />
+        <b>Cast:</b> Deal 4 damage.<br />
         You may place this card into your hand.
-        </p>
-        `,
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'promos',
+    name: 'Coruscating Sapal',
+    id: 'CoruscatingSapal',
+    cost: 4,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        You may lose 1 charge. If you do, 
+        gain an additional 2 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'promos',
+    name: 'Humming Shell',
+    id: 'HummingShell',
+    cost: 7,
+    effect: `
+      <p>
+        Destroy up to two cards in hand or discard pile.
+        <span class="or">OR</span>
+        Gain 2 charges.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'promos',
+    name: 'Force Catalyst',
+    id: 'ForceCatalyst',
+    cost: 4,
+    effect: `
+      <p>
+        While prepped, during you main phase you may spend 3 <span class="aether">&AElig;</span> 
+        to cast any player's prepped spell.<br />
+        <b>Cast:</b> Deal 3 damage.
+      </p>
+    `,
     keywords: [],
   },
 ]

--- a/src/ENG/promos/index.ts
+++ b/src/ENG/promos/index.ts
@@ -5,6 +5,7 @@ import { mages } from './mages'
 import { cards } from './cards'
 import { treasures } from './treasures'
 import { basicNemesisCards } from './basicNemesisCards'
+import { upgradedBasicNemesisCards } from './upgradedBasicNemesisCards'
 
 export const promosData: IExpansion = {
   id: 'promos',
@@ -15,4 +16,5 @@ export const promosData: IExpansion = {
   cards,
   treasures,
   basicNemesisCards,
+  upgradedBasicNemesisCards,
 }

--- a/src/ENG/promos/treasures.ts
+++ b/src/ENG/promos/treasures.ts
@@ -3,16 +3,16 @@ import { Treasure } from 'aer-types'
 export const treasures: Treasure[] = [
   {
     id: 'ReevesRavenShard',
-    name: "Reeve's RavenShard",
+    name: "Reeve's Raven Shard",
     expansion: 'promos',
     level: 1,
     subtype: 'Gem',
     effect: `
       <p>
-      Gain 1 <span class="aether">&AElig;</span>. You may discard a card in 
-      hand. If you do, gain and additional 1 <span class="aether">&AElig;</span>.
+        Gain 1 <span class="aether">&AElig;</span>. You may discard a card in 
+        hand. If you do, gain and additional 1 <span class="aether">&AElig;</span>.
       </p>
-      `,
+    `,
   },
   {
     id: 'NymsVision',
@@ -22,11 +22,11 @@ export const treasures: Treasure[] = [
     subtype: 'Spell',
     effect: `
       <p>
-      <b>Cast:</b> Deal 1 damage.<br/>
-      Reveal the top card of the nemesis deck. If you revealed an attack, gain 
-      2 <span class="aether">&AElig;</span>.
+        <b>Cast:</b> Deal 1 damage.<br />
+        Reveal the top card of the nemesis deck. If you revealed an attack, gain 
+        2 <span class="aether">&AElig;</span>.
       </p>
-      `,
+    `,
   },
   {
     id: 'SparrowsAid',
@@ -35,10 +35,10 @@ export const treasures: Treasure[] = [
     level: 1,
     effect: `
       <p>
-      <b>Cast:</b> Deal 1 damage.<br/>
-      Any ally may prep a spell in hand to their opened or closed breach(es).
+        <b>Cast:</b> Deal 1 damage.<br />
+        Any ally may prep a spell in hand to their opened or closed breach(es).
       </p>
-      `,
+    `,
   },
   {
     id: 'WraithsEssence',
@@ -47,11 +47,11 @@ export const treasures: Treasure[] = [
     level: 2,
     effect: `
       <p>
-      When a player becomse exhausted, do not resolve any on-exhaust effects.<br/>
-      <br/>
-      The players do not lose when all players are exhausted.
+        When a player becomes exhausted, do not resolve any on-exhaust effects.<br />
+        <br />
+        The players do not lose when all players are exhausted.
       </p>
-      `,
+    `,
   },
   {
     id: 'VolatileClasp',
@@ -60,10 +60,10 @@ export const treasures: Treasure[] = [
     level: 3,
     effect: `
       <p>
-      When you play a relic that costs 4 <span class="aether">&AElig;</span> 
-      or more, any ally gains 1 charge.
+        When you play a relic that costs 4 <span class="aether">&AElig;</span> 
+        or more, any ally gains 1 charge.
       </p>
-      `,
+    `,
   },
   {
     id: 'BreachStabilizer',
@@ -72,9 +72,9 @@ export const treasures: Treasure[] = [
     level: 3,
     effect: `
       <p>
-      Any number of Sparks mya be prepped to your I breach.
+        Any number of Sparks may be prepped to your I breach.
       </p>
-      `,
+    `,
   },
   {
     id: 'FangedChoker',
@@ -83,10 +83,10 @@ export const treasures: Treasure[] = [
     level: 3,
     effect: `
       <p>
-      At the end of your draw phase, if the total cost of spells in your hand 
-      is 6 <span class="aether">&AElig;</span> or more, draw a card.
+        At the end of your draw phase, if the total cost of spells in your hand 
+        is 6 <span class="aether">&AElig;</span> or more, draw a card.
       </p>
-      `,
+    `,
   },
   {
     id: 'EndlessBandolier',
@@ -95,9 +95,106 @@ export const treasures: Treasure[] = [
     level: 3,
     effect: `
       <p>
-      Once per turn during your main phase you may discard a card in hand. 
-      If you do, deal 1 damage and gain 1 charge.
+        Once per turn during your main phase you may discard a card in hand. 
+        If you do, deal 1 damage and gain 1 charge.
       </p>
-      `,
+    `,
+  },
+  {
+    id: 'SahalasBlackMeteorite',
+    name: "Sahala's Black Meteorite",
+    expansion: 'promos',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.
+        <span class="or">OR</span>
+        Gain 3 <span class="aether">&AElig;</span> that can only be used to focus 
+        or open your IV breach.
+      </p>
+    `,
+  },
+  {
+    id: 'NooksMysticFlourish',
+    name: "Nook's Mystic Flourish",
+    expansion: 'promos',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.<br />
+        Cast a spell in your hand. If that spell costs 1 <span class="aether">&AElig;</span> 
+        or more, return that spell to its supply pile, gain a spell from any supply pile that 
+        costs less than the cast spell, and gain 1 charge.
+      </p>
+    `,
+  },
+  {
+    id: 'RitualStaff',
+    name: 'Ritual Staff',
+    expansion: 'promos',
+    level: 2,
+    effect: `
+      <p>
+        When a player gains a card that costs 7 <span class="aether">&AElig;</span> or more, 
+        add a power token to this card.<br />
+        <br />
+        At the start of the nemesis turn if the nemesis has exactly one turn order card 
+        in the turn order discard pile, the nemesis suffers damage equal to the number 
+        of tokens on this card.
+      </p>
+    `,
+  },
+  {
+    id: 'CrownOfFangs',
+    name: 'Crown Of Fangs',
+    expansion: 'promos',
+    level: 2,
+    effect: `
+      <p>
+        At the start of the game, set this next to a spell supply pile that costs 
+        6 <span class="aether">&AElig;</span> or more. These cards cost player's 1 less 
+        <span class="aether">&AElig;</span> to gain.
+      </p>
+    `,
+  },
+  {
+    id: 'EverfullPurse',
+    name: 'Everfull Purse',
+    expansion: 'promos',
+    level: 3,
+    effect: `
+      <p>
+        At the end of your draw phase, if the total cost of gems and relics in your hand 
+        is 7 <span class="aether">&AElig;</span> or more, draw a card.
+      </p>
+    `,
+  },
+  {
+    id: 'ArcaneTimepiece',
+    name: 'Arcane Timepiece',
+    expansion: 'promos',
+    level: 3,
+    effect: `
+      <p>
+        At the start of your first turn of the game, gain 2 charges.<br />
+        <br />
+        Once per game when the nemesis turn order card is drawn, you may lose 4 charges. 
+        If you do, skip the nemesis turn.
+      </p>
+    `,
+  },
+  {
+    id: 'BootsOfArcaneQuickening',
+    name: 'Boots Of Arcane Quickening',
+    expansion: 'promos',
+    level: 3,
+    effect: `
+      <p>
+        At the start of your first turn of the game, gain 4 <span class="aether">&AElig;</span> 
+        that can only be used to gain a spell.
+      </p>
+    `,
   },
 ]

--- a/src/ENG/promos/upgradedBasicNemesisCards.ts
+++ b/src/ENG/promos/upgradedBasicNemesisCards.ts
@@ -1,0 +1,68 @@
+import { UpgradedBasicNemesisCard } from 'aer-types'
+
+export const upgradedBasicNemesisCards: UpgradedBasicNemesisCard[] = [
+  {
+    id: 'Writhe',
+    name: 'Writhe',
+    expansion: 'promos',
+    tier: 1,
+    type: 'Attack',
+    effect: `
+      <p>
+        Unleash twice.<br />
+        <br />
+        Any player suffers 1 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'BubblingRuin',
+    name: 'Bubbling Ruin',
+    expansion: 'promos',
+    tier: 1,
+    type: 'Power',
+    power: 3,
+    effect: `
+      <p>
+        <b>To Discard:</b> Spend 6 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 3:</b> Unleash. Any player discards three cards in hand. 
+        Gravehold suffers 2 damage.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'SweepingBlackness',
+    name: 'Sweeping Blackness',
+    expansion: 'promos',
+    tier: 2,
+    type: 'Attack',
+    effect: `
+      <p>
+        Gravehold suffers 4 damage.<br />
+        <br />
+        Any player loses 2 charges and discards two cards in hand.
+      </p>
+    `,
+    upgraded: true,
+  },
+  {
+    id: 'TwistingFlesh',
+    name: 'Twisting Flesh',
+    expansion: 'promos',
+    tier: 2,
+    type: 'Power',
+    power: 1,
+    effect: `
+      <p>
+        <b>To Discard:</b> Spend 7 <span class="aether">&AElig;</span>.<br />
+        <br />
+        <b>Power 1:</b> Unleash twice. Any player suffers 3 damage. That player gains 
+        a Cursed Manacles from the Curse deck and places it on top of their deck.
+      </p>
+    `,
+    upgraded: true,
+  },
+]

--- a/src/ENG/returnToGravehold/cards.ts
+++ b/src/ENG/returnToGravehold/cards.ts
@@ -1,0 +1,49 @@
+import { ICard } from 'aer-types'
+
+export const cards: ICard[] = [
+  {
+    type: 'Relic',
+    expansion: 'RTG',
+    name: 'Glass-Eyed Oracle',
+    id: 'GlassEyedOracle',
+    cost: 1,
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.
+        <span class="or">OR</span>
+        Destroy this and any number of copies of this card in hand. You may gain a card with cost 
+        up to three times the number of copies destroyed.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'RTG',
+    name: 'Cleanse',
+    id: 'Cleanse',
+    cost: 4,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 3 damage.<br />
+        If you have 3 or less life, gain 1 life.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'RTG',
+    name: 'Memory Break',
+    id: 'MemoryBreak',
+    cost: 6,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 3 damage.<br />
+        You may destroy a card in hand. If you do, deal additional damage equal 
+        to the cost of the destroyed card.
+      </p>
+    `,
+    keywords: [],
+  },
+]

--- a/src/ENG/returnToGravehold/index.ts
+++ b/src/ENG/returnToGravehold/index.ts
@@ -1,0 +1,16 @@
+import { IExpansion } from 'aer-types'
+
+import { nemeses } from './nemeses'
+import { mages } from './mages'
+import { cards } from './cards'
+import { treasures } from './treasures'
+
+export const returnToGraveholdData: IExpansion = {
+  id: 'RTG',
+  name: 'Return To Gravehold',
+  type: 'mini',
+  nemeses,
+  mages,
+  cards,
+  treasures,
+}

--- a/src/ENG/returnToGravehold/mages.ts
+++ b/src/ENG/returnToGravehold/mages.ts
@@ -1,0 +1,72 @@
+import { Mage } from 'aer-types'
+
+export const mages: Mage[] = [
+  {
+    expansion: 'RTG',
+    name: 'Ohat And Ulgimor',
+    id: 'OhatAndUlgimor',
+    mageTitle: '',
+    ability: `
+      <h2>Enrapture</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Ohat mode: Suffer 2 damage. Any ally draws five cards and discards two cards in hand.<br />
+        Ulgimore mode: Cast a spell prepped to Ulgimor's IV breach without discarding it.
+      </p>
+    `,
+    numberOfCharges: 4,
+    uniqueStarters: [
+      {
+        type: 'Spell',
+        name: 'Shower Of Coals',
+        expansion: 'RTG',
+        id: 'ShowerOfCoals',
+        cost: 0,
+        effect: `
+          <p>
+            Ohat Mode:<br />
+            <b>Cast:</b> Suffer 1 damage and gain 2 <span class="aether">&AElig;</span>.<br />
+            Ulgimor Mode:<br />
+            <b>Cast:</b> Deal 3 damage.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 4,
+  },
+  {
+    expansion: 'RTG',
+    name: 'Cairna',
+    id: 'Cairna',
+    mageTitle: '',
+    ability: `
+      <h2>Energize</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Gain a spell that costs 5 <span class="aether">&AElig;</span> or less from a supply pile. 
+        You may lose two charges to gain any spell from a supply pile instead. You may 
+        lose a charge to prep a spell in your discard pile to one of your opened breaches.
+      </p>
+    `,
+    numberOfCharges: 6,
+    uniqueStarters: [
+      {
+        type: 'Spell',
+        name: 'Invigorate',
+        expansion: 'RTG',
+        id: 'Invigorate',
+        cost: 0,
+        effect: `
+          <p>
+            <b>Cast:</b> Deal 1 damage.
+            <span class="or">OR</span>
+            <b>Cast:</b> Return a spell in your discard pile to your hand.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 4,
+  },
+]

--- a/src/ENG/returnToGravehold/nemeses.ts
+++ b/src/ENG/returnToGravehold/nemeses.ts
@@ -1,0 +1,22 @@
+import { Nemesis } from 'aer-types'
+
+export const nemeses: Nemesis[] = [
+  {
+    expansion: 'RTG',
+    name: 'Burrower',
+    id: 'Burrower',
+    health: 80,
+    difficulty: 8,
+    expeditionRating: 4,
+    additionalInfo: '',
+  },
+  {
+    expansion: 'RTG',
+    name: 'Fortress',
+    id: 'Fortress',
+    health: 90,
+    difficulty: 5,
+    expeditionRating: 2,
+    additionalInfo: '',
+  },
+]

--- a/src/ENG/returnToGravehold/treasures.ts
+++ b/src/ENG/returnToGravehold/treasures.ts
@@ -1,0 +1,145 @@
+import { Treasure } from 'aer-types'
+
+export const treasures: Treasure[] = [
+  {
+    id: 'ClaudiasAetherscope',
+    name: 'Claudia\'s Aetherscope',
+    expansion: 'RTG',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.
+        <span class="or">OR</span>
+        Any ally may lose 1 charge. If they do, gain 2 charges.
+      </p>
+    `,
+  },
+  {
+    id: 'SoskelsLuckyCoin',
+    name: 'Soskel\'s Lucky Coin',
+    expansion: 'RTG',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.<br />
+        You may lose 1 charge. If you do, gain an additional 2 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+  },
+  {
+    id: 'QusVoidRadite',
+    name: 'Qu\'s Void Radite',
+    expansion: 'RTG',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.<br />
+        You may cast any player's prepped spell. That spell deals 1 less damage, minimum 1.
+      </p>
+    `,
+  },
+  {
+    id: 'TaqrensGiftOfSpirit',
+    name: 'Taqren\'s Gift Of Spirit',
+    expansion: 'RTG',
+    level: 1,
+    subtype: 'Spell',
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 1 damage.
+        <span class="or">OR</span>
+        <b>Cast:</b> Any ally draws a card.
+      </p>
+    `,
+  },
+  {
+    id: 'GygarsTsunami',
+    name: 'Gygar\'s Tsunami',
+    expansion: 'RTG',
+    level: 1,
+    subtype: 'Spell',
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 1 damage.<br />
+        >ou may lose 1 charge. If you do, deal 3 additional damage.
+      </p>
+    `,
+  },
+  {
+    id: 'EnergizedHusk',
+    name: 'Energized Husk',
+    expansion: 'RTG',
+    level: 2,
+    effect: `
+      <p>
+        After a player finishes resolving their ability, any ally draws a card.
+      </p>
+    `,
+  },
+  {
+    id: 'SparkingShards',
+    name: 'Sparking Shards',
+    expansion: 'RTG',
+    level: 2,
+    effect: `
+      <p>
+        At the start of the game, set this next to a gem supply pile. When a player gains 
+        a card from that supply pile, that player gains 1 charge.
+      </p>
+    `,
+  },
+  {
+    id: 'SigilPendant',
+    name: 'Sigil Pendant',
+    expansion: 'RTG',
+    level: 2,
+    effect: `
+      <p>
+        Once per turn during any player's main phase that player may spend 3 <span class="aether">&AElig;</span> 
+        to have each player gain a charge.
+      </p>
+    `,
+  },
+  {
+    id: 'HornOfPlenty',
+    name: 'Horn Of Plenty',
+    expansion: 'RTG',
+    level: 3,
+    effect: `
+      <p>
+        Draw two cards from level 1 treasure deck and add them to the Barracks.<br />
+        <br />
+        Add two additional level 1 treasures to your starting deck using the level 1 
+        treasure rules.
+      </p>
+    `,
+  },
+  {
+    id: 'ImbuedCirclet',
+    name: 'Imbued Circlet',
+    expansion: 'RTG',
+    level: 3,
+    effect: `
+      <p>
+        When you gain a gem, Gravehold gains 1 life.<br />
+        <br />
+        This can cause Gravehold to have more than its maximum life.
+      </p>
+    `,
+  },
+  {
+    id: 'BurstingBracelet',
+    name: 'Bursting Bracelet',
+    expansion: 'RTG',
+    level: 3,
+    effect: `
+      <p>
+        When you focus or open a breach, you may cast any player's prepped spell. 
+        That spell deals 1 additional damage.
+      </p>
+    `,
+  },
+]

--- a/src/ENG/southernVillage/cards.ts
+++ b/src/ENG/southernVillage/cards.ts
@@ -1,0 +1,155 @@
+import { ICard } from 'aer-types'
+
+export const cards: ICard[] = [
+  {
+    type: 'Gem',
+    expansion: 'SV',
+    name: 'Quickening Qitite',
+    id: 'QuickeningQitite',
+    cost: 3,
+    effect: `
+      <p>
+        Gain 2 <span class="aether">&AElig;</span>.<br />
+        You may discard a card in hand. If you do, focus any player's II breach.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Gem',
+    expansion: 'SV',
+    name: 'Jeweled Urup',
+    id: 'JeweledUrup',
+    cost: 5,
+    effect: `
+      <p>
+        Gain 3 <span class="aether">&AElig;</span>.
+        <span class="or">OR</span>
+        If this is the second time you have played Jeweled Urup this turn, 
+        you may destroy this. If you do, gain a card from any supply pile 
+        that costs 7 <span class="aether">&AElig;</span> or less.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'SV',
+    name: 'Cat\'s Eye',
+    id: 'CatsEye',
+    cost: 1,
+    effect: `
+      <p>
+        You cannot gain this card if you have gained another card this turn. You cannot 
+        gain any other cards the turn you gain this.<br />
+        Gain 1 charge. You may destroy this. If you do, gain 1 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'SV',
+    name: 'Volt Replicator',
+    id: 'VoltReplicator',
+    cost: 4,
+    effect: `
+      <p>
+        Any ally gains a card that costs 5 <span class="aether">&AElig;</span> or less. 
+        If there are two or fewer Volt Replicator in the supply, you may destroy this. If you do, 
+        place the gained card into that ally's hand instead.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Relic',
+    expansion: 'SV',
+    name: 'Energized Conduit',
+    id: 'EnergizedConduit',
+    cost: 7,
+    effect: `
+      <p>
+        <b>Attach</b> this to any player's breach.
+      </p>
+      <p>
+        When a spell is cast from this breach, the player who cast that spell gains 1 charge.
+      </p>
+    `,
+    keywords: ['attach'],
+  },
+  {
+    type: 'Spell',
+    expansion: 'SV',
+    name: 'Flame Jab',
+    id: 'FlameJab',
+    cost: 1,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 2 damage to a minion.<br />
+        You may destroy this. If you do, gain 1 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'SV',
+    name: 'Gathering Winds',
+    id: 'GatheringWinds',
+    cost: 3,
+    effect: `
+      <p>
+        <b>Cast:</b> Deal 2 damage.<br />
+        If there are six or more other cards in your discard pile, focus any player's breach.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'SV',
+    name: 'Cinder Shower',
+    id: 'CinderShower',
+    cost: 5,
+    effect: `
+      <p>
+        While prepped, when you gain a card, deal 1 damage.<br />
+        <b>Cast:</br> Deal 3 damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'SV',
+    name: 'Reaper\'s Flame',
+    id: 'ReapersFlame',
+    cost: 7,
+    effect: `
+      <p>
+        While prepped, once per turn when you cast another spell, you may gain a card that costs 
+        5 <span class="aether">&AElig;</span> or less from any supply pile.<br />
+        <b>Cast:</br> Deal 5 damage.
+      </p>
+    `,
+    keywords: [],
+  },
+  {
+    type: 'Spell',
+    expansion: 'SV',
+    name: 'Erasure Of Mind',
+    id: 'ErasureOfMind',
+    cost: 7,
+    effect: `
+      <p>
+        <b>Cast:</b> Destroy a card in hand that costs 3<span class="aether">&AElig;</span> or more. 
+        If you do, deal 10 damage.
+        <span class="or">OR</span>
+        <b>Cast:</b> Deal 5 damage. Reveal the top two cards of your deck and place any number on top 
+        of your discard pile.
+      </p>
+    `,
+    keywords: [],
+  },
+]

--- a/src/ENG/southernVillage/index.ts
+++ b/src/ENG/southernVillage/index.ts
@@ -1,0 +1,16 @@
+import { IExpansion } from 'aer-types'
+
+import { nemeses } from './nemeses'
+import { mages } from './mages'
+import { cards } from './cards'
+import { treasures } from './treasures'
+
+export const southernVillageData: IExpansion = {
+  id: 'SV',
+  name: 'Southern Village',
+  type: 'mini',
+  nemeses,
+  mages,
+  cards,
+  treasures,
+}

--- a/src/ENG/southernVillage/mages.ts
+++ b/src/ENG/southernVillage/mages.ts
@@ -1,0 +1,71 @@
+import { Mage } from 'aer-types'
+
+export const mages: Mage[] = [
+  {
+    expansion: 'SV',
+    name: 'Lucien',
+    id: 'Lucien',
+    mageTitle: '',
+    ability: `
+      <h2>Magnetism</h2>
+      <p class="ability-activation">Activate during your casting phase:</p>
+      <p>
+        Open all of your breaches. Prep any number of spells in hand to your opened breaches.
+      </p>
+    `,
+    numberOfCharges: 5,
+    uniqueStarters: [
+      {
+        type: 'Gem',
+        name: 'Sun Shard',
+        expansion: 'SV',
+        id: 'SunShard',
+        cost: 0,
+        effect: `
+          <p>
+            Gain 1 <span class="aether">&AElig;</span>.
+            <span class="or">OR</span>
+            Gain 3 <span class="aether">&AElig;</span> that can only be used to open a breach.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 7,
+  },
+  {
+    expansion: 'SV',
+    name: 'Reth',
+    id: 'Reth',
+    mageTitle: '',
+    ability: `
+      <h2>Missing Half</h2>
+      <p class="ability-activation">Activate during your main phase:</p>
+      <p>
+        Reveal your deck. Place up to two spells with the same name from your deck into 
+        your hand, and up to two spells with that same name from your discard into 
+        your hand. Return your deck in the same order.
+      </p>
+    `,
+    numberOfCharges: 5,
+    uniqueStarters: [
+      {
+        type: 'Spell',
+        name: 'Fossilized Rose',
+        expansion: 'SV',
+        id: 'FossilizedRose',
+        cost: 0,
+        effect: `
+          <p>
+            <b>Cast:</b> Discard a card in hand. If you do, gain a spell that costs 
+            5 <span class="aether">&AElig;</span> or less from any supply pile.
+            <span class="or">OR</span>
+            <b>Cast:</b> Deal 1 damage.
+          </p>
+        `,
+        keywords: [],
+      },
+    ],
+    complexityRating: 5,
+  },
+]

--- a/src/ENG/southernVillage/nemeses.ts
+++ b/src/ENG/southernVillage/nemeses.ts
@@ -1,0 +1,13 @@
+import { Nemesis } from 'aer-types'
+
+export const nemeses: Nemesis[] = [
+  {
+    expansion: 'SV',
+    name: 'The Burning Kor',
+    id: 'TheBurningKor',
+    health: 60,
+    difficulty: 7,
+    expeditionRating: 4,
+    additionalInfo: '',
+  },
+]

--- a/src/ENG/southernVillage/treasures.ts
+++ b/src/ENG/southernVillage/treasures.ts
@@ -1,0 +1,79 @@
+import { Treasure } from 'aer-types'
+
+export const treasures: Treasure[] = [
+  {
+    id: 'IncosSpreadingEmerald',
+    name: 'Inco\'s Spreading Emerald',
+    expansion: 'SV',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        Gain 1 <span class="aether">&AElig;</span>.
+        <span class="or">OR</span>
+        The next time you gain a card that costs 3 <span class="aether">&AElig;</span> 
+        or less this turn, any ally gains a copy of that card from the supply.
+      </p>
+    `,
+  },
+  {
+    id: 'LostsForgedCrystal',
+    name: 'Lost\'s Forged Crystal',
+    expansion: 'SV',
+    level: 1,
+    subtype: 'Gem',
+    effect: `
+      <p>
+        <span class="hint">(When the game starts, add a Crystal to your discard pile.)</span><br />
+        Gain 2 <span class="aether">&AElig;</span>.
+      </p>
+    `,
+  },
+  {
+    id: 'OnyxElixir',
+    name: 'Onyx Elixir',
+    expansion: 'SV',
+    level: 2,
+    effect: `
+      <p>
+        At the start of the game, set this next to a supply pile that costs 
+        7 <span class="aether">&AElig;</span> or more. When a player gains a card 
+        from that supply pile, that player gains 2 life.
+      </p>
+    `,
+  },
+  {
+    id: 'AshenRib',
+    name: 'Ashen Rib',
+    expansion: 'SV',
+    level: 2,
+    effect: `
+      <p>
+        Once per turn after a player plays their second relic, any ally draws a card.
+      </p>
+    `,
+  },
+  {
+    id: 'MassacreHelm',
+    name: 'Massacre Helm',
+    expansion: 'SV',
+    level: 3,
+    effect: `
+      <p>
+        When you cast three or more spells during your casting phase, deal 3 damage.
+      </p>
+    `,
+  },
+  {
+    id: 'CloakOfWisdom',
+    name: 'Cloak Of Wisdom',
+    expansion: 'SV',
+    level: 3,
+    effect: `
+      <p>
+        At the start of tyour main phase, if there are five or more cards in your 
+        discard pile, focus one of your closed breaches.
+      </p>
+    `,
+  },
+]

--- a/src/ENG/theDepths/mages.ts
+++ b/src/ENG/theDepths/mages.ts
@@ -62,7 +62,7 @@ export const mages: Mage[] = [
   },
   {
     expansion: 'Depths',
-    name: 'Zhana',
+    name: 'Z\'hana',
     id: 'Zhana',
     mageTitle: 'Breach Mage Renegade',
     ability: `


### PR DESCRIPTION
Contains english content for the following expansions:

- Aeon's End: Outcasts
- Return To Gravehold
- Southern Village
- Promos of wave 5